### PR TITLE
Fix for breaking change in tunic 0.4.0.

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function soyparser(text) {
     namespace: extractNamespace(text),
     templates: []
   };
-  var ast = tunic().parse(text);
+  var ast = new Tunic().parse(text);
   ast.blocks.forEach(extractTemplates.bind(null, parsed.templates, ast.blocks));
   return parsed;
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   ],
   "dependencies": {
     "merge": "^1.2.0",
-    "tunic": "^0.3.0"
+    "tunic": "^0.4.0"
   }
 }


### PR DESCRIPTION
I dropped the functional style usage of `tunic` after an internal refactor to ES6. Just making sure I don't break your stuff.
